### PR TITLE
Added elementary as 2nd fallback icon theme

### DIFF
--- a/Arc/index.theme
+++ b/Arc/index.theme
@@ -1,6 +1,6 @@
 [Icon Theme]
 Name=Arc
-Inherits=Moka,elementary,Adwaita,gnome,hicolor
+Inherits=Moka,Faba,elementary,Adwaita,gnome,hicolor
 Comment=Arc Icon theme
 
 #Directory list

--- a/Arc/index.theme
+++ b/Arc/index.theme
@@ -1,6 +1,6 @@
 [Icon Theme]
 Name=Arc
-Inherits=Moka,Adwaita,gnome,hicolor
+Inherits=Moka,elementary,Adwaita,gnome,hicolor
 Comment=Arc Icon theme
 
 #Directory list


### PR DESCRIPTION
Elementary is available as official arch package here:
https://www.archlinux.org/packages/community/any/elementary-icon-theme/

Also see #9
