### PR TITLE
fix battery icons' level not being accurate

### DIFF
--- a/Arc/status/symbolic/battery-good-charging-symbolic.svg
+++ b/Arc/status/symbolic/battery-good-charging-symbolic.svg
@@ -13,7 +13,7 @@
    height="16"
    id="svg2"
    sodipodi:version="0.32"
-   inkscape:version="0.48.3.1 r9886"
+   inkscape:version="0.91 r13725"
    version="1.0"
    sodipodi:docname="battery-good-charging-symbolic.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
@@ -27,9 +27,9 @@
      borderopacity="1"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="15.810166"
-     inkscape:cx="-34.304835"
-     inkscape:cy="3.7029117"
+     inkscape:zoom="63.240664"
+     inkscape:cx="12.987962"
+     inkscape:cy="7.8164084"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="true"
@@ -37,9 +37,9 @@
      showguides="false"
      inkscape:guide-bbox="true"
      inkscape:window-width="1920"
-     inkscape:window-height="1029"
+     inkscape:window-height="998"
      inkscape:window-x="0"
-     inkscape:window-y="24"
+     inkscape:window-y="27"
      inkscape:window-maximized="1">
     <sodipodi:guide
        orientation="1,0"
@@ -85,38 +85,15 @@
      inkscape:label="Icon"
      inkscape:groupmode="layer"
      id="layer1"
-     style="display:inline"
-     transform="translate(0,-6)">
-    <rect
-       style="color:#000000;fill:#4e9a06;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect2999"
-       width="7"
-       height="10"
-       x="24"
-       y="10"
-       rx="0.5" />
+     style="display:inline">
     <path
-       inkscape:connector-curvature="0"
-       style="fill:#bebebe;fill-opacity:1;stroke:none;display:inline"
-       d="m -18,20.75 c 0,0.6925 0.5575,1.25 1.25,1.25 l 8.5,0 C -7.5575,22 -7,21.4425 -7,20.75 L -7,9.25 C -7,8.5575 -7.5575,8 -8.25,8 L -10,8 -10,7 -10,6.5 C -10,6.223 -10.223,6 -10.5,6 l -0.5,0 -3,0 -0.5,0 C -14.777,6 -15,6.223 -15,6.5 l 0,0.5 0,1 -1.75,0 C -17.4425,8 -18,8.5575 -18,9.25 l 0,11.5 z m 2,-1.5 0,-8.5 c 0,-0.4155 0.3345,-0.75 0.75,-0.75 l 5.5,0 c 0.4155,0 0.75,0.3345 0.75,0.75 l 0,8.5 C -9,19.6655 -9.3345,20 -9.75,20 l -5.5,0 C -15.6655,20 -16,19.6655 -16,19.25 z"
-       id="path3775" />
-    <rect
-       rx="0.5"
-       y="10"
-       x="-16"
-       height="10"
-       width="7"
-       id="rect3011"
-       style="opacity:0.45;color:#000000;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.45;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:8;marker:none;enable-background:accumulate"
+       d="m 6.5114165,0.99560398 c -0.277,0 -0.5,0.22300002 -0.5,0.50000002 l 0,0.5 -2,0 c -0.554,0 -1,0.446 -1,1 l 0,11.000001 c 0,0.554 0.446,1 1,1 l 8.0000005,0 c 0.554,0 1,-0.446 1,-1 l 0,-11.000001 c 0,-0.554 -0.446,-1 -1,-1 l -2,0 0,-0.5 c 0,-0.277 -0.2230005,-0.50000002 -0.5000005,-0.50000002 l -3,0 z m 0.5,3.00000002 4.0000005,6.0000008 -2.4687505,0 0.46875,4.0000002 -4,-6.000001 2.5,0 -0.5,-4 z"
+       id="path3000"
+       inkscape:connector-curvature="0" />
     <path
-       style="color:#000000;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:8;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;opacity:0.45"
-       d="M 6.5 1 C 6.223 1 6 1.223 6 1.5 L 6 2 L 4 2 C 3.446 2 3 2.446 3 3 L 3 14 C 3 14.554 3.446 15 4 15 L 12 15 C 12.554 15 13 14.554 13 14 L 13 3 C 13 2.446 12.554 2 12 2 L 10 2 L 10 1.5 C 10 1.223 9.777 1 9.5 1 L 6.5 1 z M 7 4 L 11 10 L 8.53125 10 L 9 14 L 5 8 L 7.5 8 L 7 4 z "
-       transform="translate(0,6)"
-       id="path3000" />
-    <path
-       style="color:#000000;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:8;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       d="m 3,5 0,9 c 0,0.554 0.446,1 1,1 l 8,0 c 0.554,0 1,-0.446 1,-1 L 13,5 7.65625,5 11,10 8.53125,10 9,14 5,8 7.5,8 7.125,5 3,5 z"
-       transform="translate(0,6)"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:8;marker:none;enable-background:accumulate"
+       d="m 3.0114165,8.0114166 0,6.0000004 c 0,0.554 0.446,1 1,1 l 8.0000005,0 c 0.554,0 1,-0.446 1,-1 l 0,-6.0000004 -3.3437505,0 1.3437505,1.9999994 -2.4687505,0 0.46875,4.000001 -4,-6.0000004 -2,0 z"
        id="path3002"
        inkscape:connector-curvature="0" />
   </g>

--- a/Arc/status/symbolic/battery-good-symbolic.svg
+++ b/Arc/status/symbolic/battery-good-symbolic.svg
@@ -13,7 +13,7 @@
    height="16"
    id="svg2"
    sodipodi:version="0.32"
-   inkscape:version="0.48.3.1 r9886"
+   inkscape:version="0.91 r13725"
    version="1.0"
    sodipodi:docname="battery-good-symbolic.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
@@ -27,19 +27,19 @@
      borderopacity="1"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="10.118506"
-     inkscape:cx="-48.007593"
-     inkscape:cy="4.7777456"
+     inkscape:zoom="63.240666"
+     inkscape:cx="6.1504289"
+     inkscape:cy="9.6079375"
      inkscape:document-units="px"
-     inkscape:current-layer="layer1"
+     inkscape:current-layer="svg2"
      showgrid="true"
      inkscape:showpageshadow="false"
      showguides="false"
      inkscape:guide-bbox="true"
      inkscape:window-width="1920"
-     inkscape:window-height="1029"
+     inkscape:window-height="998"
      inkscape:window-x="0"
-     inkscape:window-y="24"
+     inkscape:window-y="27"
      inkscape:window-maximized="1">
     <sodipodi:guide
        orientation="1,0"
@@ -85,43 +85,16 @@
      inkscape:label="Icon"
      inkscape:groupmode="layer"
      id="layer1"
-     style="display:inline"
-     transform="translate(0,-6)">
-    <rect
-       style="color:#000000;fill:#4e9a06;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect2999"
-       width="7"
-       height="10"
-       x="24"
-       y="10"
-       rx="0.5" />
+     style="display:inline">
     <path
-       inkscape:connector-curvature="0"
-       style="fill:#bebebe;fill-opacity:1;stroke:none;display:inline"
-       d="m -18,20.75 c 0,0.6925 0.5575,1.25 1.25,1.25 l 8.5,0 C -7.5575,22 -7,21.4425 -7,20.75 L -7,9.25 C -7,8.5575 -7.5575,8 -8.25,8 L -10,8 -10,7 -10,6.5 C -10,6.223 -10.223,6 -10.5,6 l -0.5,0 -3,0 -0.5,0 C -14.777,6 -15,6.223 -15,6.5 l 0,0.5 0,1 -1.75,0 C -17.4425,8 -18,8.5575 -18,9.25 l 0,11.5 z m 2,-1.5 0,-8.5 c 0,-0.4155 0.3345,-0.75 0.75,-0.75 l 5.5,0 c 0.4155,0 0.75,0.3345 0.75,0.75 l 0,8.5 C -9,19.6655 -9.3345,20 -9.75,20 l -5.5,0 C -15.6655,20 -16,19.6655 -16,19.25 z"
-       id="path3775" />
-    <rect
-       rx="0.5"
-       y="10"
-       x="-16"
-       height="10"
-       width="7"
-       id="rect3011"
-       style="opacity:0.45;color:#000000;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <path
-       style="color:#000000;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:8;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;opacity:0.45"
-       d="M 6.5,7 C 6.223,7 6,7.223 6,7.5 L 6,8 4,8 C 3.446,8 3,8.446 3,9 l 0,11 c 0,0.554 0.446,1 1,1 l 8,0 c 0.554,0 1,-0.446 1,-1 L 13,9 C 13,8.446 12.554,8 12,8 L 10,8 10,7.5 C 10,7.223 9.777,7 9.5,7 z"
-       id="path3000" />
-    <path
-       style="color:#000000;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:8;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       d="M 7,30 11,36 8.5415237,36 9,40 5,34 7.5036033,34 z"
-       id="rect3771"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.45;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:8;marker:none;enable-background:accumulate"
+       d="m 6.5011898,0.99529831 c -0.277,0 -0.5,0.22299999 -0.5,0.49999999 l 0,0.5 -2,0 c -0.554,0 -1,0.446 -1,1 l 0,11.0000007 c 0,0.554 0.446,1 1,1 l 8.0000002,0 c 0.554,0 1,-0.446 1,-1 l 0,-11.0000007 c 0,-0.554 -0.446,-1 -1,-1 l -2,0 0,-0.5 c 0,-0.277 -0.2230002,-0.49999999 -0.5000002,-0.49999999 z"
+       id="path3000"
        inkscape:connector-curvature="0" />
     <path
-       style="color:#000000;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:8;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       d="m 3,11 0,9 c 0,0.554 0.446,1 1,1 l 8,0 c 0.554,0 1,-0.446 1,-1 l 0,-9 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:8;marker:none;enable-background:accumulate"
+       d="m 3.0114167,8.0114167 0,6.0000003 c 0,0.554 0.446,1 1,1 l 8.0000003,0 c 0.554,0 1,-0.446 1,-1 l 0,-6.0000003 z"
        id="path3002"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="csssscc" />
+       inkscape:connector-curvature="0" />
   </g>
 </svg>

--- a/Arc/status/symbolic/battery-low-charging-symbolic.svg
+++ b/Arc/status/symbolic/battery-low-charging-symbolic.svg
@@ -13,9 +13,9 @@
    height="16"
    id="svg2"
    sodipodi:version="0.32"
-   inkscape:version="0.48.3.1 r9886"
+   inkscape:version="0.91 r13725"
    version="1.0"
-   sodipodi:docname="battery-low-charging-symbolic.svg"
+   sodipodi:docname="battery-caution-charging-symbolic.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    style="display:inline">
   <defs
@@ -27,12 +27,12 @@
      borderopacity="1"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="15.810166"
-     inkscape:cx="-34.304835"
-     inkscape:cy="3.7029117"
+     inkscape:zoom="1"
+     inkscape:cx="5.6602104"
+     inkscape:cy="6.0118438"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
-     showgrid="true"
+     showgrid="false"
      inkscape:showpageshadow="false"
      showguides="false"
      inkscape:guide-bbox="true"
@@ -40,7 +40,11 @@
      inkscape:window-height="1029"
      inkscape:window-x="0"
      inkscape:window-y="24"
-     inkscape:window-maximized="1">
+     inkscape:window-maximized="1"
+     inkscape:snap-bbox="true"
+     inkscape:object-paths="true"
+     inkscape:object-nodes="true"
+     inkscape:snap-bbox-midpoints="true">
     <sodipodi:guide
        orientation="1,0"
        position="0,112"
@@ -87,37 +91,15 @@
      id="layer1"
      style="display:inline"
      transform="translate(0,-6)">
-    <rect
-       style="color:#000000;fill:#4e9a06;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect2999"
-       width="7"
-       height="10"
-       x="24"
-       y="10"
-       rx="0.5" />
     <path
-       inkscape:connector-curvature="0"
-       style="fill:#bebebe;fill-opacity:1;stroke:none;display:inline"
-       d="m -18,20.75 c 0,0.6925 0.5575,1.25 1.25,1.25 l 8.5,0 C -7.5575,22 -7,21.4425 -7,20.75 L -7,9.25 C -7,8.5575 -7.5575,8 -8.25,8 L -10,8 -10,7 -10,6.5 C -10,6.223 -10.223,6 -10.5,6 l -0.5,0 -3,0 -0.5,0 C -14.777,6 -15,6.223 -15,6.5 l 0,0.5 0,1 -1.75,0 C -17.4425,8 -18,8.5575 -18,9.25 l 0,11.5 z m 2,-1.5 0,-8.5 c 0,-0.4155 0.3345,-0.75 0.75,-0.75 l 5.5,0 c 0.4155,0 0.75,0.3345 0.75,0.75 l 0,8.5 C -9,19.6655 -9.3345,20 -9.75,20 l -5.5,0 C -15.6655,20 -16,19.6655 -16,19.25 z"
-       id="path3775" />
-    <rect
-       rx="0.5"
-       y="10"
-       x="-16"
-       height="10"
-       width="7"
-       id="rect3011"
-       style="opacity:0.45;color:#000000;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <path
-       style="color:#000000;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:8;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;opacity:0.45"
+       style="opacity:0.45;color:#000000;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:8;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
        d="M 6.5 1 C 6.223 1 6 1.223 6 1.5 L 6 2 L 4 2 C 3.446 2 3 2.446 3 3 L 3 14 C 3 14.554 3.446 15 4 15 L 12 15 C 12.554 15 13 14.554 13 14 L 13 3 C 13 2.446 12.554 2 12 2 L 10 2 L 10 1.5 C 10 1.223 9.777 1 9.5 1 L 6.5 1 z M 7 4 L 11 10 L 8.53125 10 L 9 14 L 5 8 L 7.5 8 L 7 4 z "
        transform="translate(0,6)"
        id="path3000" />
     <path
        style="color:#000000;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:8;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       d="m 3,8 0,6 c 0,0.554 0.446,1 1,1 l 8,0 c 0.554,0 1,-0.446 1,-1 L 13,8 9.65625,8 11,10 8.53125,10 9,14 5,8 3,8 z"
-       transform="translate(0,6)"
+       d="M 3 11 L 3 14 C 3 14.554 3.446 15 4 15 L 12 15 C 12.554 15 13 14.554 13 14 L 13 11 L 8.65625 11 L 9 14 L 7 11 L 3 11 z "
        id="path3002"
-       inkscape:connector-curvature="0" />
+       transform="translate(0,6)" />
   </g>
 </svg>

--- a/Arc/status/symbolic/battery-low-symbolic.svg
+++ b/Arc/status/symbolic/battery-low-symbolic.svg
@@ -13,7 +13,7 @@
    height="16"
    id="svg2"
    sodipodi:version="0.32"
-   inkscape:version="0.48.3.1 r9886"
+   inkscape:version="0.91 r13725"
    version="1.0"
    sodipodi:docname="battery-low-symbolic.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
@@ -27,19 +27,19 @@
      borderopacity="1"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="15.810166"
-     inkscape:cx="-31.59832"
-     inkscape:cy="3.7029117"
+     inkscape:zoom="16"
+     inkscape:cx="-17.8402"
+     inkscape:cy="6.8544776"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
-     showgrid="true"
+     showgrid="false"
      inkscape:showpageshadow="false"
      showguides="false"
      inkscape:guide-bbox="true"
      inkscape:window-width="1920"
-     inkscape:window-height="1029"
+     inkscape:window-height="998"
      inkscape:window-x="0"
-     inkscape:window-y="24"
+     inkscape:window-y="27"
      inkscape:window-maximized="1">
     <sodipodi:guide
        orientation="1,0"
@@ -87,39 +87,14 @@
      id="layer1"
      style="display:inline"
      transform="translate(0,-6)">
-    <rect
-       style="color:#000000;fill:#4e9a06;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect2999"
-       width="7"
-       height="10"
-       x="24"
-       y="10"
-       rx="0.5" />
     <path
        inkscape:connector-curvature="0"
-       style="fill:#bebebe;fill-opacity:1;stroke:none;display:inline"
-       d="m -18,20.75 c 0,0.6925 0.5575,1.25 1.25,1.25 l 8.5,0 C -7.5575,22 -7,21.4425 -7,20.75 L -7,9.25 C -7,8.5575 -7.5575,8 -8.25,8 L -10,8 -10,7 -10,6.5 C -10,6.223 -10.223,6 -10.5,6 l -0.5,0 -3,0 -0.5,0 C -14.777,6 -15,6.223 -15,6.5 l 0,0.5 0,1 -1.75,0 C -17.4425,8 -18,8.5575 -18,9.25 l 0,11.5 z m 2,-1.5 0,-8.5 c 0,-0.4155 0.3345,-0.75 0.75,-0.75 l 5.5,0 c 0.4155,0 0.75,0.3345 0.75,0.75 l 0,8.5 C -9,19.6655 -9.3345,20 -9.75,20 l -5.5,0 C -15.6655,20 -16,19.6655 -16,19.25 z"
-       id="path3775" />
-    <rect
-       rx="0.5"
-       y="10"
-       x="-16"
-       height="10"
-       width="7"
-       id="rect3011"
-       style="opacity:0.45;color:#000000;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <path
-       style="color:#000000;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:8;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;opacity:0.45"
+       style="opacity:0.45;color:#000000;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:8;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
        d="M 6.5,7 C 6.223,7 6,7.223 6,7.5 L 6,8 4,8 C 3.446,8 3,8.446 3,9 l 0,11 c 0,0.554 0.446,1 1,1 l 8,0 c 0.554,0 1,-0.446 1,-1 L 13,9 C 13,8.446 12.554,8 12,8 L 10,8 10,7.5 C 10,7.223 9.777,7 9.5,7 z"
        id="path3000" />
     <path
-       style="color:#000000;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:8;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       d="M 7,30 11,36 8.5415237,36 9,40 5,34 7.5036033,34 z"
-       id="rect3771"
-       inkscape:connector-curvature="0" />
-    <path
-       style="color:#000000;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:8;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       d="m 3,14 0,6 c 0,0.554 0.446,1 1,1 l 8,0 c 0.554,0 1,-0.446 1,-1 l 0,-6 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:8;marker:none;enable-background:accumulate"
+       d="m 3,17 0,3 c 0,0.554 0.446,1 1,1 l 8,0 c 0.554,0 1,-0.446 1,-1 l 0,-3 z"
        id="path3002"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="csssscc" />


### PR DESCRIPTION
Fixed the battery icons. This only work for gnome (or anything that used symbolic).
The four battery levels are critical (red low), low (white low), good (medium), full (max).
Anything above 30% until full, looks half full, but that's the limitation of gnome (I think, not sure. The documentations suck - not even up to date, had to work off of gnome/gnome-icon-theme-symbolic)
Fixes issue #11 (a hack-ey fix for gnome only)
